### PR TITLE
♻️ Replace axios with native fetch API

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -36,7 +36,6 @@
     "access": "public"
   },
   "dependencies": {
-    "axios": "^1.9.0",
     "dotenv": "^16.5.0",
     "form-data": "^4.0.3",
     "ts-node": "^10.9.2"
@@ -44,7 +43,6 @@
   "devDependencies": {
     "@types/jest": "^29.5.14",
     "@types/node": "^22.15.23",
-    "axios-mock-adapter": "^2.1.0",
     "esbuild-plugin-alias": "^0.2.1",
     "jest": "^29.7.0",
     "ts-jest": "^29.3.4",

--- a/packages/sdk/src/client/AuthRequest.ts
+++ b/packages/sdk/src/client/AuthRequest.ts
@@ -1,6 +1,5 @@
 import { handleResponse } from '@utils';
 import { AuthRequestOptions, TikTokAPIResponse } from '@types';
-import axios from 'axios';
 
 const AUTH_BASE_URL = 'https://auth.tiktok-shops.com';
 
@@ -17,12 +16,12 @@ export async function authRequest<T>({ method, path, query, body }: AuthRequestO
         'Content-Type': 'application/json',
     };
 
-    const response = await axios.request({
-        url: url.toString(),
+    const response = await fetch(url.toString(), {
         method,
         headers,
-        data: body,
+        body: body ? JSON.stringify(body) : undefined,
     });
 
-    return handleResponse<T>(response.data);
+    const data = await response.json();
+    return handleResponse<T>(data);
 }

--- a/packages/sdk/src/client/RequestMultipart.ts
+++ b/packages/sdk/src/client/RequestMultipart.ts
@@ -1,5 +1,4 @@
 import { generateSignature } from '@utils';
-import axios from 'axios';
 import FormData from 'form-data';
 
 interface MultipartRequestOptions {
@@ -63,12 +62,12 @@ export async function requestMultipart({
         headers['x-tts-access-token'] = config.accessToken;
     }
 
-    const response = await axios.request({
-        url: url.toString(),
+    const response = await fetch(url.toString(), {
         method,
         headers,
-        data: body,
+        body: body as unknown as BodyInit,
     });
 
-    return response.data;
+    const data = await response.json();
+    return data;
 }

--- a/packages/sdk/src/client/__tests__/authRequest.test.ts
+++ b/packages/sdk/src/client/__tests__/authRequest.test.ts
@@ -1,12 +1,10 @@
-import axios from 'axios';
 import { authRequest } from '../AuthRequest'; // Adjust path if different
 import { handleResponse } from '@utils/handleResponse'; // Adjust path if different
 import { AccessTokenResponse, AuthRequestOptions } from '@types'
 
-// Mock the entire axios module to prevent actual HTTP requests during tests.
-jest.mock('axios');
-// Cast axios to a Mocked object to access Jest's mock methods.
-const mockedAxios = axios as jest.Mocked<typeof axios>;
+// Mock fetch
+global.fetch = jest.fn();
+const mockedFetch = fetch as jest.MockedFunction<typeof fetch>;
 
 // Mock the handleResponse utility function to control its behavior and track calls.
 jest.mock('@utils/handleResponse'); // Adjust path if different
@@ -20,7 +18,7 @@ describe('authRequest', () => {
     // Before each test, clear all mock calls and reset their implementations.
     // This ensures tests are isolated and don't affect each other.
     beforeEach(() => {
-        mockedAxios.request.mockClear();
+        mockedFetch.mockClear();
         mockedHandleResponse.mockClear();
     });
 
@@ -32,8 +30,11 @@ describe('authRequest', () => {
         // Define the mock data that handleResponse is expected to return after processing.
         const mockHandledResponse = { code: 403545, message: "auth_code not found", request_id: "02740234923942" };
 
-        // Configure the mocked axios.request to resolve successfully with the mock API data.
-        mockedAxios.request.mockResolvedValueOnce({ data: mockApiResponseData });
+        // Configure the mocked fetch to resolve successfully with the mock API data.
+        mockedFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => mockApiResponseData,
+        } as Response);
         // Configure the mocked handleResponse to return the predefined handled response data.
         mockedHandleResponse.mockReturnValueOnce(mockHandledResponse);
 
@@ -54,20 +55,132 @@ describe('authRequest', () => {
 
         // --- Assertions ---
 
-        // Verify that axios.request was called exactly once.
-        expect(mockedAxios.request).toHaveBeenCalledTimes(1);
-        // Verify that axios.request was called with the correct parameters,
+        // Verify that fetch was called exactly once.
+        expect(mockedFetch).toHaveBeenCalledTimes(1);
+        // Verify that fetch was called with the correct parameters,
         // including the constructed URL with all query parameters.
-        expect(mockedAxios.request).toHaveBeenCalledWith({
-            url: `${AUTH_BASE_URL}/api/v2/token/get?app_key=app-key&app_secret=app-secret&grant_type=authorized_code&auth_code=ROW_893jhkdfgd...`,
-            method: 'GET',
-            headers: { 'Content-Type': 'application/json' },
-            data: undefined, // For GET requests, the 'data' field should be undefined.
-        });
+        expect(mockedFetch).toHaveBeenCalledWith(
+            `${AUTH_BASE_URL}/api/v2/token/get?app_key=app-key&app_secret=app-secret&grant_type=authorized_code&auth_code=ROW_893jhkdfgd...`,
+            {
+                method: 'GET',
+                headers: { 'Content-Type': 'application/json' },
+                body: undefined, // For GET requests, the 'body' field should be undefined.
+            }
+        );
 
         // Verify that handleResponse was called exactly once.
         expect(mockedHandleResponse).toHaveBeenCalledTimes(1);
-        // Verify that handleResponse was called with the raw API response data from axios.
+        // Verify that handleResponse was called with the raw API response data from fetch.
+        expect(mockedHandleResponse).toHaveBeenCalledWith(mockApiResponseData);
+
+        // Verify that the final result of authRequest matches the data returned by the mocked handleResponse.
+        expect(result).toEqual(mockHandledResponse);
+    });
+
+    test('should make a GET request without body and return handled response', async () => {
+        // Define the mock API response data that fetch will return.
+        const mockApiResponseData = { code: 0, message: 'Success' };
+        // Define the mock data that handleResponse is expected to return after processing.
+        const mockHandledResponse = { code: 0, message: "Success", request_id: "123" };
+
+        // Configure the mocked fetch to resolve successfully with the mock API data.
+        mockedFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => mockApiResponseData,
+        } as Response);
+        // Configure the mocked handleResponse to return the predefined handled response data.
+        mockedHandleResponse.mockReturnValueOnce(mockHandledResponse);
+
+        // Define the options for the authRequest function without body.
+        const options: AuthRequestOptions = {
+            method: 'GET',
+            path: '/api/v2/token/refresh',
+            query: {
+                app_key: "app-key",
+                refresh_token: "refresh-token",
+            },
+            // No body provided
+        };
+
+        // Call the authRequest function with the defined options.
+        const result = await authRequest<AccessTokenResponse>(options);
+
+        // --- Assertions ---
+
+        // Verify that fetch was called exactly once.
+        expect(mockedFetch).toHaveBeenCalledTimes(1);
+        // Verify that fetch was called with the correct parameters,
+        // including undefined body for GET requests without data.
+        expect(mockedFetch).toHaveBeenCalledWith(
+            `${AUTH_BASE_URL}/api/v2/token/refresh?app_key=app-key&refresh_token=refresh-token`,
+            {
+                method: 'GET',
+                headers: { 'Content-Type': 'application/json' },
+                body: undefined, // Should be undefined when no body is provided.
+            }
+        );
+
+        // Verify that handleResponse was called exactly once.
+        expect(mockedHandleResponse).toHaveBeenCalledTimes(1);
+        // Verify that handleResponse was called with the raw API response data from fetch.
+        expect(mockedHandleResponse).toHaveBeenCalledWith(mockApiResponseData);
+
+        // Verify that the final result of authRequest matches the data returned by the mocked handleResponse.
+        expect(result).toEqual(mockHandledResponse);
+    });
+
+    test('should make a POST request with body and return handled response', async () => {
+        // Define the mock API response data that fetch will return.
+        const mockApiResponseData = { code: 0, message: 'Success', data: { access_token: 'new-token' } };
+        // Define the mock data that handleResponse is expected to return after processing.
+        const mockHandledResponse = { code: 0, message: "Success", request_id: "456" };
+
+        // Configure the mocked fetch to resolve successfully with the mock API data.
+        mockedFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => mockApiResponseData,
+        } as Response);
+        // Configure the mocked handleResponse to return the predefined handled response data.
+        mockedHandleResponse.mockReturnValueOnce(mockHandledResponse);
+
+        // Define the options for the authRequest function with body.
+        const options: AuthRequestOptions = {
+            method: 'POST',
+            path: '/api/v2/token/get',
+            body: {
+                app_key: "app-key",
+                app_secret: "app-secret",
+                grant_type: 'authorized_code',
+                auth_code: "ROW_893jhkdfgd...",
+            },
+        };
+
+        // Call the authRequest function with the defined options.
+        const result = await authRequest<AccessTokenResponse>(options);
+
+        // --- Assertions ---
+
+        // Verify that fetch was called exactly once.
+        expect(mockedFetch).toHaveBeenCalledTimes(1);
+        // Verify that fetch was called with the correct parameters,
+        // including body with JSON.stringify for POST requests.
+        expect(mockedFetch).toHaveBeenCalledWith(
+            `${AUTH_BASE_URL}/api/v2/token/get`,
+            {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    app_key: "app-key",
+                    app_secret: "app-secret",
+                    grant_type: 'authorized_code',
+                    auth_code: "ROW_893jhkdfgd...",
+                }), // Should be JSON.stringify when body is provided.
+            }
+        );
+
+        // Verify that handleResponse was called exactly once.
+        expect(mockedHandleResponse).toHaveBeenCalledTimes(1);
+        // Verify that handleResponse was called with the raw API response data from fetch.
         expect(mockedHandleResponse).toHaveBeenCalledWith(mockApiResponseData);
 
         // Verify that the final result of authRequest matches the data returned by the mocked handleResponse.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,9 +66,6 @@ importers:
 
   packages/sdk:
     dependencies:
-      axios:
-        specifier: ^1.9.0
-        version: 1.10.0
       dotenv:
         specifier: ^16.5.0
         version: 16.6.1
@@ -85,9 +82,6 @@ importers:
       '@types/node':
         specifier: ^22.15.23
         version: 22.15.33
-      axios-mock-adapter:
-        specifier: ^2.1.0
-        version: 2.1.0(axios@1.10.0)
       esbuild-plugin-alias:
         specifier: ^0.2.1
         version: 0.2.1
@@ -954,14 +948,6 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  axios-mock-adapter@2.1.0:
-    resolution: {integrity: sha512-AZUe4OjECGCNNssH8SOdtneiQELsqTsat3SQQCWLPjN436/H+L9AjWfV7bF+Zg/YL9cgbhrz5671hoh+Tbn98w==}
-    peerDependencies:
-      axios: '>= 0.17.0'
-
-  axios@1.10.0:
-    resolution: {integrity: sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==}
-
   babel-jest@29.7.0:
     resolution: {integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -1349,15 +1335,6 @@ packages:
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
-  follow-redirects@1.15.9:
-    resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
@@ -1500,10 +1477,6 @@ packages:
 
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
-
-  is-buffer@2.0.5:
-    resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
-    engines: {node: '>=4'}
 
   is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
@@ -2028,9 +2001,6 @@ packages:
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
-
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -3369,20 +3339,6 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  axios-mock-adapter@2.1.0(axios@1.10.0):
-    dependencies:
-      axios: 1.10.0
-      fast-deep-equal: 3.1.3
-      is-buffer: 2.0.5
-
-  axios@1.10.0:
-    dependencies:
-      follow-redirects: 1.15.9
-      form-data: 4.0.3
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
   babel-jest@29.7.0(@babel/core@7.27.7):
     dependencies:
       '@babel/core': 7.27.7
@@ -3826,8 +3782,6 @@ snapshots:
 
   flatted@3.3.3: {}
 
-  follow-redirects@1.15.9: {}
-
   foreground-child@3.3.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -3958,8 +3912,6 @@ snapshots:
   inherits@2.0.4: {}
 
   is-arrayish@0.2.1: {}
-
-  is-buffer@2.0.5: {}
 
   is-core-module@2.16.1:
     dependencies:
@@ -4683,8 +4635,6 @@ snapshots:
     dependencies:
       kleur: 3.0.3
       sisteransi: 1.0.5
-
-  proxy-from-env@1.1.0: {}
 
   punycode@2.3.1: {}
 


### PR DESCRIPTION
Refactor HTTP client implementation to use native fetch API instead of axios. This reduces dependencies and bundle size while maintaining the same functionality. Updated all related tests to use fetch mocking.