### PR TITLE
feat(apps/docs): add Shop Webhooks API pages (Get, Update, Delete)

### DIFF
--- a/apps/docs/src/routes/[lang]/docs/core/event/delete-shop-webhook/+page.svelte
+++ b/apps/docs/src/routes/[lang]/docs/core/event/delete-shop-webhook/+page.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
-    import { onMount } from 'svelte';
-    import { Store, FileSearch } from 'lucide-svelte';
-    import { codeToHtml } from 'shiki';
-    import { theme } from '$lib/stores/theme';
+	import { onMount } from 'svelte';
+	import { Store, FileSearch } from 'lucide-svelte';
+	import { codeToHtml } from 'shiki';
+	import { theme } from '$lib/stores/theme';
 
-    let exampleCode = '';
-    let responseJSON = '';
+	let exampleCode = '';
+	let responseJSON = '';
 
-    const tsExample = `
+	const tsExample = `
 import { TikTokShopSDK, TikTokAPIError } from 'tiktok-shop-sdk';
 
 const sdk = new TikTokShopSDK({
@@ -36,7 +36,7 @@ try {
 }
 `;
 
-    const jsonExample = `
+	const jsonExample = `
 {
   "code": 0,
   "data": {},
@@ -45,132 +45,132 @@ try {
 }
 `;
 
-    async function renderShiki() {
-        const selectedTheme = $theme === 'dark' ? 'material-theme-darker' : 'github-light';
+	async function renderShiki() {
+		const selectedTheme = $theme === 'dark' ? 'material-theme-darker' : 'github-light';
 
-        exampleCode = await codeToHtml(tsExample, {
-            lang: 'ts',
-            themes: { dark: selectedTheme, light: selectedTheme }
-        });
+		exampleCode = await codeToHtml(tsExample, {
+			lang: 'ts',
+			themes: { dark: selectedTheme, light: selectedTheme }
+		});
 
-        responseJSON = await codeToHtml(jsonExample, {
-            lang: 'json',
-            themes: { dark: selectedTheme, light: selectedTheme }
-        });
-    }
+		responseJSON = await codeToHtml(jsonExample, {
+			lang: 'json',
+			themes: { dark: selectedTheme, light: selectedTheme }
+		});
+	}
 
-    onMount(() => {
-        document.title = 'Delete Shop Webhook – TikTok Shop SDK';
-        renderShiki();
-    });
+	onMount(() => {
+		document.title = 'Delete Shop Webhook – TikTok Shop SDK';
+		renderShiki();
+	});
 
-    $: if ($theme) renderShiki();
+	$: if ($theme) renderShiki();
 </script>
 
 <div class="prose max-w-none space-y-10 prose-slate dark:prose-invert">
-    <!-- Header -->
-    <section class="space-y-2">
-        <h1 class="flex items-center gap-2 text-3xl font-bold">
-            <Store class="h-7 w-7 text-purple-500" />
-            Delete Shop Webhook
-        </h1>
+	<!-- Header -->
+	<section class="space-y-2">
+		<h1 class="flex items-center gap-2 text-3xl font-bold">
+			<Store class="h-7 w-7 text-purple-500" />
+			Delete Shop Webhook
+		</h1>
 
-        <p class="text-lg">
-            Delete an existing webhook subscription for a shop. This API is used to remove event
-            notifications such as message listeners or order updates.
-        </p>
-    </section>
+		<p class="text-lg">
+			Delete an existing webhook subscription for a shop. This API is used to remove event
+			notifications such as message listeners or order updates.
+		</p>
+	</section>
 
-    <hr />
+	<hr />
 
-    <!-- Requirements -->
-    <section id="requirements" class="space-y-3">
-        <h2 class="flex items-center gap-2">
-            <FileSearch class="h-5 w-5 text-blue-500" />
-            Requirements
-        </h2>
+	<!-- Requirements -->
+	<section id="requirements" class="space-y-3">
+		<h2 class="flex items-center gap-2">
+			<FileSearch class="h-5 w-5 text-blue-500" />
+			Requirements
+		</h2>
 
-        <ul>
-            <li>A valid seller <strong>Access Token</strong></li>
-            <li>A valid <strong>Shop Cipher</strong> (encrypted shop identifier)</li>
-            <li>Use <code>event.deleteShopWebhook()</code> from the SDK</li>
-        </ul>
+		<ul>
+			<li>A valid seller <strong>Access Token</strong></li>
+			<li>A valid <strong>Shop Cipher</strong> (encrypted shop identifier)</li>
+			<li>Use <code>event.deleteShopWebhook()</code> from the SDK</li>
+		</ul>
 
-        <p>
-            Official documentation:
-            <a
-                href="https://partner.tiktokshop.com/docv2/page/delete-shop-webhook-202309"
-                target="_blank"
-                class="text-blue-600 underline dark:text-blue-400"
-            >
-                TikTok Shop – Delete Shop Webhook
-            </a>
-        </p>
-    </section>
+		<p>
+			Official documentation:
+			<a
+				href="https://partner.tiktokshop.com/docv2/page/delete-shop-webhook-202309"
+				target="_blank"
+				class="text-blue-600 underline dark:text-blue-400"
+			>
+				TikTok Shop – Delete Shop Webhook
+			</a>
+		</p>
+	</section>
 
-    <hr />
+	<hr />
 
-    <!-- Usage Example -->
-    <section id="usage" class="space-y-3">
-        <h2 class="flex items-center gap-2">
-            <Store class="h-5 w-5 text-green-500" />
-            Usage Example
-        </h2>
+	<!-- Usage Example -->
+	<section id="usage" class="space-y-3">
+		<h2 class="flex items-center gap-2">
+			<Store class="h-5 w-5 text-green-500" />
+			Usage Example
+		</h2>
 
-        <p>This example shows how to delete a webhook subscription for a shop.</p>
+		<p>This example shows how to delete a webhook subscription for a shop.</p>
 
-        <div class="rounded-xl border border-border-light dark:border-border-dark">
-            {@html exampleCode}
-        </div>
-    </section>
+		<div class="rounded-xl border border-border-light dark:border-border-dark">
+			{@html exampleCode}
+		</div>
+	</section>
 
-    <hr />
+	<hr />
 
-    <!-- Response Example -->
-    <section id="response" class="space-y-3">
-        <h2>Response Example</h2>
+	<!-- Response Example -->
+	<section id="response" class="space-y-3">
+		<h2>Response Example</h2>
 
-        <p>This is a real example returned by TikTok Shop:</p>
+		<p>This is a real example returned by TikTok Shop:</p>
 
-        <div class="overflow-hidden rounded-xl border border-border-light dark:border-border-dark">
-            {@html responseJSON}
-        </div>
+		<div class="overflow-hidden rounded-xl border border-border-light dark:border-border-dark">
+			{@html responseJSON}
+		</div>
 
-        <p class="mt-3">The response contains:</p>
+		<p class="mt-3">The response contains:</p>
 
-        <ul>
-            <li><strong>code</strong> — API status code (0 means success)</li>
-            <li><strong>data</strong> — empty object (no additional payload)</li>
-            <li><strong>message</strong> — response message (e.g., "Success")</li>
-            <li><strong>request_id</strong> — unique identifier for the API request</li>
-        </ul>
-    </section>
+		<ul>
+			<li><strong>code</strong> — API status code (0 means success)</li>
+			<li><strong>data</strong> — empty object (no additional payload)</li>
+			<li><strong>message</strong> — response message (e.g., "Success")</li>
+			<li><strong>request_id</strong> — unique identifier for the API request</li>
+		</ul>
+	</section>
 
-    <hr />
+	<hr />
 
-    <!-- Errors -->
-    <section id="errors" class="space-y-3">
-        <h2>Error Handling</h2>
+	<!-- Errors -->
+	<section id="errors" class="space-y-3">
+		<h2>Error Handling</h2>
 
-        <p>
-            All API errors throw <code>TikTokAPIError</code>, which contains:
-        </p>
+		<p>
+			All API errors throw <code>TikTokAPIError</code>, which contains:
+		</p>
 
-        <ul>
-            <li><strong>message</strong></li>
-            <li><strong>code</strong></li>
-            <li><strong>request_id</strong></li>
-        </ul>
+		<ul>
+			<li><strong>message</strong></li>
+			<li><strong>code</strong></li>
+			<li><strong>request_id</strong></li>
+		</ul>
 
-        <p>
-            Full error reference:
-            <a
-                href="https://partner.tiktokshop.com/docv2/page/common-errors"
-                target="_blank"
-                class="text-blue-600 underline dark:text-blue-400"
-            >
-                TikTok Common Errors
-            </a>
-        </p>
-    </section>
+		<p>
+			Full error reference:
+			<a
+				href="https://partner.tiktokshop.com/docv2/page/common-errors"
+				target="_blank"
+				class="text-blue-600 underline dark:text-blue-400"
+			>
+				TikTok Common Errors
+			</a>
+		</p>
+	</section>
 </div>

--- a/apps/docs/src/routes/[lang]/docs/core/event/get-shop-webhooks/+page.svelte
+++ b/apps/docs/src/routes/[lang]/docs/core/event/get-shop-webhooks/+page.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
-    import { onMount } from 'svelte';
-    import { Store, FileSearch } from 'lucide-svelte';
-    import { codeToHtml } from 'shiki';
-    import { theme } from '$lib/stores/theme';
+	import { onMount } from 'svelte';
+	import { Store, FileSearch } from 'lucide-svelte';
+	import { codeToHtml } from 'shiki';
+	import { theme } from '$lib/stores/theme';
 
-    let exampleCode = '';
-    let responseJSON = '';
+	let exampleCode = '';
+	let responseJSON = '';
 
-    const tsExample = `
+	const tsExample = `
 import { TikTokShopSDK, TikTokAPIError } from 'tiktok-shop-sdk';
 
 const sdk = new TikTokShopSDK({
@@ -34,7 +34,7 @@ try {
 }
 `;
 
-    const jsonExample = `
+	const jsonExample = `
 {
   "code": 0,
   "data": {
@@ -53,134 +53,134 @@ try {
 }
 `;
 
-    async function renderShiki() {
-        const selectedTheme = $theme === 'dark' ? 'material-theme-darker' : 'github-light';
+	async function renderShiki() {
+		const selectedTheme = $theme === 'dark' ? 'material-theme-darker' : 'github-light';
 
-        exampleCode = await codeToHtml(tsExample, {
-            lang: 'ts',
-            themes: { dark: selectedTheme, light: selectedTheme }
-        });
+		exampleCode = await codeToHtml(tsExample, {
+			lang: 'ts',
+			themes: { dark: selectedTheme, light: selectedTheme }
+		});
 
-        responseJSON = await codeToHtml(jsonExample, {
-            lang: 'json',
-            themes: { dark: selectedTheme, light: selectedTheme }
-        });
-    }
+		responseJSON = await codeToHtml(jsonExample, {
+			lang: 'json',
+			themes: { dark: selectedTheme, light: selectedTheme }
+		});
+	}
 
-    onMount(() => {
-        document.title = 'Get Shop Webhooks – TikTok Shop SDK';
-        renderShiki();
-    });
+	onMount(() => {
+		document.title = 'Get Shop Webhooks – TikTok Shop SDK';
+		renderShiki();
+	});
 
-    $: if ($theme) renderShiki();
+	$: if ($theme) renderShiki();
 </script>
 
 <div class="prose max-w-none space-y-10 prose-slate dark:prose-invert">
-    <!-- Header -->
-    <section class="space-y-2">
-        <h1 class="flex items-center gap-2 text-3xl font-bold">
-            <Store class="h-7 w-7 text-purple-500" />
-            Get Shop Webhooks
-        </h1>
+	<!-- Header -->
+	<section class="space-y-2">
+		<h1 class="flex items-center gap-2 text-3xl font-bold">
+			<Store class="h-7 w-7 text-purple-500" />
+			Get Shop Webhooks
+		</h1>
 
-        <p class="text-lg">
-            Retrieve all webhook subscriptions configured for a shop. Useful for monitoring events such
-            as order status changes, product updates, and logistics notifications.
-        </p>
-    </section>
+		<p class="text-lg">
+			Retrieve all webhook subscriptions configured for a shop. Useful for monitoring events such as
+			order status changes, product updates, and logistics notifications.
+		</p>
+	</section>
 
-    <hr />
+	<hr />
 
-    <!-- Requirements -->
-    <section id="requirements" class="space-y-3">
-        <h2 class="flex items-center gap-2">
-            <FileSearch class="h-5 w-5 text-blue-500" />
-            Requirements
-        </h2>
+	<!-- Requirements -->
+	<section id="requirements" class="space-y-3">
+		<h2 class="flex items-center gap-2">
+			<FileSearch class="h-5 w-5 text-blue-500" />
+			Requirements
+		</h2>
 
-        <ul>
-            <li>A valid seller <strong>Access Token</strong></li>
-            <li>A valid <strong>Shop Cipher</strong> (encrypted shop identifier)</li>
-            <li>Use <code>event.getShopWebhooks()</code> from the SDK</li>
-        </ul>
+		<ul>
+			<li>A valid seller <strong>Access Token</strong></li>
+			<li>A valid <strong>Shop Cipher</strong> (encrypted shop identifier)</li>
+			<li>Use <code>event.getShopWebhooks()</code> from the SDK</li>
+		</ul>
 
-        <p>
-            Official documentation:
-            <a
-                href="https://partner.tiktokshop.com/docv2/page/get-shop-webhooks-202309"
-                target="_blank"
-                class="text-blue-600 underline dark:text-blue-400"
-            >
-                TikTok Shop – Get Shop Webhooks
-            </a>
-        </p>
-    </section>
+		<p>
+			Official documentation:
+			<a
+				href="https://partner.tiktokshop.com/docv2/page/get-shop-webhooks-202309"
+				target="_blank"
+				class="text-blue-600 underline dark:text-blue-400"
+			>
+				TikTok Shop – Get Shop Webhooks
+			</a>
+		</p>
+	</section>
 
-    <hr />
+	<hr />
 
-    <!-- Usage Example -->
-    <section id="usage" class="space-y-3">
-        <h2 class="flex items-center gap-2">
-            <Store class="h-5 w-5 text-green-500" />
-            Usage Example
-        </h2>
+	<!-- Usage Example -->
+	<section id="usage" class="space-y-3">
+		<h2 class="flex items-center gap-2">
+			<Store class="h-5 w-5 text-green-500" />
+			Usage Example
+		</h2>
 
-        <p>This example shows how to retrieve all webhook subscriptions for a shop.</p>
+		<p>This example shows how to retrieve all webhook subscriptions for a shop.</p>
 
-        <div class="rounded-xl border border-border-light dark:border-border-dark">
-            {@html exampleCode}
-        </div>
-    </section>
+		<div class="rounded-xl border border-border-light dark:border-border-dark">
+			{@html exampleCode}
+		</div>
+	</section>
 
-    <hr />
+	<hr />
 
-    <!-- Response Example -->
-    <section id="response" class="space-y-3">
-        <h2>Response Example</h2>
+	<!-- Response Example -->
+	<section id="response" class="space-y-3">
+		<h2>Response Example</h2>
 
-        <p>This is a real example returned by TikTok Shop:</p>
+		<p>This is a real example returned by TikTok Shop:</p>
 
-        <div class="overflow-hidden rounded-xl border border-border-light dark:border-border-dark">
-            {@html responseJSON}
-        </div>
+		<div class="overflow-hidden rounded-xl border border-border-light dark:border-border-dark">
+			{@html responseJSON}
+		</div>
 
-        <p class="mt-3">Each <code>webhooks</code> entry contains:</p>
+		<p class="mt-3">Each <code>webhooks</code> entry contains:</p>
 
-        <ul>
-            <li><strong>event_type</strong> — type of event (e.g., ORDER_STATUS_CHANGE)</li>
-            <li><strong>address</strong> — webhook callback URL</li>
-            <li><strong>create_time</strong> — creation timestamp (Unix)</li>
-            <li><strong>update_time</strong> — last update timestamp (Unix)</li>
-        </ul>
+		<ul>
+			<li><strong>event_type</strong> — type of event (e.g., ORDER_STATUS_CHANGE)</li>
+			<li><strong>address</strong> — webhook callback URL</li>
+			<li><strong>create_time</strong> — creation timestamp (Unix)</li>
+			<li><strong>update_time</strong> — last update timestamp (Unix)</li>
+		</ul>
 
-        <p><strong>total_count</strong> indicates the number of webhooks configured for the shop.</p>
-    </section>
+		<p><strong>total_count</strong> indicates the number of webhooks configured for the shop.</p>
+	</section>
 
-    <hr />
+	<hr />
 
-    <!-- Errors -->
-    <section id="errors" class="space-y-3">
-        <h2>Error Handling</h2>
+	<!-- Errors -->
+	<section id="errors" class="space-y-3">
+		<h2>Error Handling</h2>
 
-        <p>
-            All API errors throw <code>TikTokAPIError</code>, which contains:
-        </p>
+		<p>
+			All API errors throw <code>TikTokAPIError</code>, which contains:
+		</p>
 
-        <ul>
-            <li><strong>message</strong></li>
-            <li><strong>code</strong></li>
-            <li><strong>request_id</strong></li>
-        </ul>
+		<ul>
+			<li><strong>message</strong></li>
+			<li><strong>code</strong></li>
+			<li><strong>request_id</strong></li>
+		</ul>
 
-        <p>
-            Full error reference:
-            <a
-                href="https://partner.tiktokshop.com/docv2/page/common-errors"
-                target="_blank"
-                class="text-blue-600 underline dark:text-blue-400"
-            >
-                TikTok Common Errors
-            </a>
-        </p>
-    </section>
+		<p>
+			Full error reference:
+			<a
+				href="https://partner.tiktokshop.com/docv2/page/common-errors"
+				target="_blank"
+				class="text-blue-600 underline dark:text-blue-400"
+			>
+				TikTok Common Errors
+			</a>
+		</p>
+	</section>
 </div>

--- a/apps/docs/src/routes/[lang]/docs/core/event/update-shop-webhook/+page.svelte
+++ b/apps/docs/src/routes/[lang]/docs/core/event/update-shop-webhook/+page.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
-    import { onMount } from 'svelte';
-    import { Store, FileSearch } from 'lucide-svelte';
-    import { codeToHtml } from 'shiki';
-    import { theme } from '$lib/stores/theme';
+	import { onMount } from 'svelte';
+	import { Store, FileSearch } from 'lucide-svelte';
+	import { codeToHtml } from 'shiki';
+	import { theme } from '$lib/stores/theme';
 
-    let exampleCode = '';
-    let responseJSON = '';
+	let exampleCode = '';
+	let responseJSON = '';
 
-    const tsExample = `
+	const tsExample = `
 import { TikTokShopSDK, TikTokAPIError } from 'tiktok-shop-sdk';
 
 const sdk = new TikTokShopSDK({
@@ -37,7 +37,7 @@ try {
 }
 `;
 
-    const jsonExample = `
+	const jsonExample = `
 {
   "code": 0,
   "data": {},
@@ -46,132 +46,132 @@ try {
 }
 `;
 
-    async function renderShiki() {
-        const selectedTheme = $theme === 'dark' ? 'material-theme-darker' : 'github-light';
+	async function renderShiki() {
+		const selectedTheme = $theme === 'dark' ? 'material-theme-darker' : 'github-light';
 
-        exampleCode = await codeToHtml(tsExample, {
-            lang: 'ts',
-            themes: { dark: selectedTheme, light: selectedTheme }
-        });
+		exampleCode = await codeToHtml(tsExample, {
+			lang: 'ts',
+			themes: { dark: selectedTheme, light: selectedTheme }
+		});
 
-        responseJSON = await codeToHtml(jsonExample, {
-            lang: 'json',
-            themes: { dark: selectedTheme, light: selectedTheme }
-        });
-    }
+		responseJSON = await codeToHtml(jsonExample, {
+			lang: 'json',
+			themes: { dark: selectedTheme, light: selectedTheme }
+		});
+	}
 
-    onMount(() => {
-        document.title = 'Update Shop Webhook – TikTok Shop SDK';
-        renderShiki();
-    });
+	onMount(() => {
+		document.title = 'Update Shop Webhook – TikTok Shop SDK';
+		renderShiki();
+	});
 
-    $: if ($theme) renderShiki();
+	$: if ($theme) renderShiki();
 </script>
 
 <div class="prose max-w-none space-y-10 prose-slate dark:prose-invert">
-    <!-- Header -->
-    <section class="space-y-2">
-        <h1 class="flex items-center gap-2 text-3xl font-bold">
-            <Store class="h-7 w-7 text-purple-500" />
-            Update Shop Webhook
-        </h1>
+	<!-- Header -->
+	<section class="space-y-2">
+		<h1 class="flex items-center gap-2 text-3xl font-bold">
+			<Store class="h-7 w-7 text-purple-500" />
+			Update Shop Webhook
+		</h1>
 
-        <p class="text-lg">
-            Update an existing webhook subscription for a shop. This API is used to change the callback
-            URL or event type for notifications such as order updates or address changes.
-        </p>
-    </section>
+		<p class="text-lg">
+			Update an existing webhook subscription for a shop. This API is used to change the callback
+			URL or event type for notifications such as order updates or address changes.
+		</p>
+	</section>
 
-    <hr />
+	<hr />
 
-    <!-- Requirements -->
-    <section id="requirements" class="space-y-3">
-        <h2 class="flex items-center gap-2">
-            <FileSearch class="h-5 w-5 text-blue-500" />
-            Requirements
-        </h2>
+	<!-- Requirements -->
+	<section id="requirements" class="space-y-3">
+		<h2 class="flex items-center gap-2">
+			<FileSearch class="h-5 w-5 text-blue-500" />
+			Requirements
+		</h2>
 
-        <ul>
-            <li>A valid seller <strong>Access Token</strong></li>
-            <li>A valid <strong>Shop Cipher</strong> (encrypted shop identifier)</li>
-            <li>Use <code>event.updateShopWebhook()</code> from the SDK</li>
-        </ul>
+		<ul>
+			<li>A valid seller <strong>Access Token</strong></li>
+			<li>A valid <strong>Shop Cipher</strong> (encrypted shop identifier)</li>
+			<li>Use <code>event.updateShopWebhook()</code> from the SDK</li>
+		</ul>
 
-        <p>
-            Official documentation:
-            <a
-                href="https://partner.tiktokshop.com/docv2/page/update-shop-webhook-202309"
-                target="_blank"
-                class="text-blue-600 underline dark:text-blue-400"
-            >
-                TikTok Shop – Update Shop Webhook
-            </a>
-        </p>
-    </section>
+		<p>
+			Official documentation:
+			<a
+				href="https://partner.tiktokshop.com/docv2/page/update-shop-webhook-202309"
+				target="_blank"
+				class="text-blue-600 underline dark:text-blue-400"
+			>
+				TikTok Shop – Update Shop Webhook
+			</a>
+		</p>
+	</section>
 
-    <hr />
+	<hr />
 
-    <!-- Usage Example -->
-    <section id="usage" class="space-y-3">
-        <h2 class="flex items-center gap-2">
-            <Store class="h-5 w-5 text-green-500" />
-            Usage Example
-        </h2>
+	<!-- Usage Example -->
+	<section id="usage" class="space-y-3">
+		<h2 class="flex items-center gap-2">
+			<Store class="h-5 w-5 text-green-500" />
+			Usage Example
+		</h2>
 
-        <p>This example shows how to update a webhook subscription for a shop.</p>
+		<p>This example shows how to update a webhook subscription for a shop.</p>
 
-        <div class="rounded-xl border border-border-light dark:border-border-dark">
-            {@html exampleCode}
-        </div>
-    </section>
+		<div class="rounded-xl border border-border-light dark:border-border-dark">
+			{@html exampleCode}
+		</div>
+	</section>
 
-    <hr />
+	<hr />
 
-    <!-- Response Example -->
-    <section id="response" class="space-y-3">
-        <h2>Response Example</h2>
+	<!-- Response Example -->
+	<section id="response" class="space-y-3">
+		<h2>Response Example</h2>
 
-        <p>This is a real example returned by TikTok Shop:</p>
+		<p>This is a real example returned by TikTok Shop:</p>
 
-        <div class="overflow-hidden rounded-xl border border-border-light dark:border-border-dark">
-            {@html responseJSON}
-        </div>
+		<div class="overflow-hidden rounded-xl border border-border-light dark:border-border-dark">
+			{@html responseJSON}
+		</div>
 
-        <p class="mt-3">The response contains:</p>
+		<p class="mt-3">The response contains:</p>
 
-        <ul>
-            <li><strong>code</strong> — API status code (0 means success)</li>
-            <li><strong>data</strong> — empty object (no additional payload)</li>
-            <li><strong>message</strong> — response message (e.g., "Success")</li>
-            <li><strong>request_id</strong> — unique identifier for the API request</li>
-        </ul>
-    </section>
+		<ul>
+			<li><strong>code</strong> — API status code (0 means success)</li>
+			<li><strong>data</strong> — empty object (no additional payload)</li>
+			<li><strong>message</strong> — response message (e.g., "Success")</li>
+			<li><strong>request_id</strong> — unique identifier for the API request</li>
+		</ul>
+	</section>
 
-    <hr />
+	<hr />
 
-    <!-- Errors -->
-    <section id="errors" class="space-y-3">
-        <h2>Error Handling</h2>
+	<!-- Errors -->
+	<section id="errors" class="space-y-3">
+		<h2>Error Handling</h2>
 
-        <p>
-            All API errors throw <code>TikTokAPIError</code>, which contains:
-        </p>
+		<p>
+			All API errors throw <code>TikTokAPIError</code>, which contains:
+		</p>
 
-        <ul>
-            <li><strong>message</strong></li>
-            <li><strong>code</strong></li>
-            <li><strong>request_id</strong></li>
-        </ul>
+		<ul>
+			<li><strong>message</strong></li>
+			<li><strong>code</strong></li>
+			<li><strong>request_id</strong></li>
+		</ul>
 
-        <p>
-            Full error reference:
-            <a
-                href="https://partner.tiktokshop.com/docv2/page/common-errors"
-                target="_blank"
-                class="text-blue-600 underline dark:text-blue-400"
-            >
-                TikTok Common Errors
-            </a>
-        </p>
-    </section>
+		<p>
+			Full error reference:
+			<a
+				href="https://partner.tiktokshop.com/docv2/page/common-errors"
+				target="_blank"
+				class="text-blue-600 underline dark:text-blue-400"
+			>
+				TikTok Common Errors
+			</a>
+		</p>
+	</section>
 </div>


### PR DESCRIPTION
This PR introduces documentation pages for TikTok Shop Webhooks APIs:

- **Get Shop Webhooks**: Retrieve all webhook subscriptions for a shop
- **Update Shop Webhook**: Update callback URL or event type for existing subscriptions
- **Delete Shop Webhook**: Remove webhook subscriptions by event type

Each page includes:
- Requirements section (Access Token, Shop Cipher)
- Usage example with Shiki-rendered TypeScript code
- Response example with Shiki-rendered JSON
- Error handling reference with TikTokAPIError details
- Links to official TikTok Shop documentation