### PR TITLE
docs(return-and-refund): document cancellation, return, and aftersale eligibility endpoints

### DIFF
--- a/apps/docs/core-api/return-and-refund/approve-cancellation.md
+++ b/apps/docs/core-api/return-and-refund/approve-cancellation.md
@@ -1,0 +1,131 @@
+# Approve Cancellation
+
+Approve a buyer's cancellation request in TikTok Shop.
+
+Official documentation:\
+https://partner.tiktokshop.com/docv2/page/approve-cancellation-202309
+
+---
+
+## Requirements
+
+- A valid **Access Token**
+- A valid **Shop Cipher**
+- SDK Method: `return_refund.approveCancellation()`
+
+---
+
+## Parameters
+
+### Path / Main Parameters
+
+Field Type Description
+
+---
+
+`cancel_id` string The cancellation request ID. **Required**
+
+---
+
+### Query Parameters
+
+---
+
+Field Type Description
+
+---
+
+`idempotency_key` string Unique key to prevent duplicate approvals.
+
+---
+
+---
+
+## Example Usage (TypeScript)
+
+```ts
+import { TikTokShopSDK, TikTokAPIError } from 'tiktok-shop-sdk';
+
+const sdk = new TikTokShopSDK({
+  appKey: process.env.TIKTOK_APP_KEY!,
+  appSecret: process.env.TIKTOK_APP_SECRET!,
+});
+
+try {
+  // Set Access Token
+  sdk.setAccessToken(process.env.TIKTOK_APP_ACCESS_KEY!);
+  sdk.setShopCipher(process.env.TIKTOK_SHOP_CIPHER!);
+
+  const response = await sdk.return_refund.approveCancellation({
+    cancel_id: '09830495345435',
+    query: {
+      idempotency_key: '03498530l94056',
+    },
+  });
+
+  console.log(JSON.stringify(response));
+} catch (error) {
+  if (error instanceof TikTokAPIError) {
+    console.error('TikTok API Error:', error.message);
+    console.error('Status Code:', error.code);
+    console.log('Request Id: ', error.request_id);
+  } else {
+    console.error('Unexpected error:', error);
+  }
+}
+```
+
+---
+
+## Response Example
+
+```json
+{
+  "code": 0,
+  "data": {
+    "success": true,
+    "status": "CANCELLATION_APPROVED"
+  },
+  "message": "Success",
+  "request_id": "202407031400112233445566778899"
+}
+```
+
+---
+
+## Response Descriptions
+
+### Top-Level Fields
+
+Field Type Description
+
+---
+
+`code` int API status code (0 = success).
+`message` string Operation message.
+`request_id` string Unique request identifier.
+`data` object Contains approval result.
+
+---
+
+### `data` Object
+
+Field Type Description
+
+---
+
+`success` boolean Whether approval was successful.
+`status` string Final status of the cancellation request.
+
+---
+
+## Error Handling
+
+All API errors will throw a `TikTokAPIError` containing:
+
+- **message**
+- **code**
+- **request_id**
+
+Full error reference:\
+https://partner.tiktokshop.com/docv2/page/approve-cancellation-202309#Error_Code

--- a/apps/docs/core-api/return-and-refund/approve-return.md
+++ b/apps/docs/core-api/return-and-refund/approve-return.md
@@ -1,0 +1,137 @@
+# Approve Return
+
+Approve or reject a return request in TikTok Shop.
+
+Official documentation:  
+https://partner.tiktokshop.com/docv2/page/approve-return-202309
+
+---
+
+## Requirements
+
+- A valid **Access Token**
+- A valid **Shop Cipher**
+- SDK Method: `return_refund.approveReturn()`
+
+---
+
+## Parameters
+
+### Path / Main Parameters
+
+| Field       | Type   | Description                         |
+| ----------- | ------ | ----------------------------------- |
+| `return_id` | string | The return request ID. **Required** |
+
+---
+
+### Query Parameters
+
+| Field             | Type   | Description                              |
+| ----------------- | ------ | ---------------------------------------- |
+| `idempotency_key` | string | Unique key to prevent duplicate actions. |
+
+---
+
+### Body Parameters
+
+| Field             | Type    | Description                                            |
+| ----------------- | ------- | ------------------------------------------------------ |
+| `decision`        | string  | Decision value, e.g., `APPROVE_RETURN`. **Required**   |
+| `buyer_keep_item` | boolean | Whether buyer keeps the item.                          |
+| `partial_refund`  | object  | Optional partial refund object (`currency`, `amount`). |
+
+---
+
+## Example Usage (TypeScript)
+
+```ts
+import { TikTokShopSDK, TikTokAPIError } from 'tiktok-shop-sdk';
+
+const sdk = new TikTokShopSDK({
+  appKey: process.env.TIKTOK_APP_KEY!,
+  appSecret: process.env.TIKTOK_APP_SECRET!,
+});
+
+try {
+  // Set Access Token
+  sdk.setAccessToken(process.env.TIKTOK_APP_ACCESS_KEY!);
+  sdk.setShopCipher(process.env.TIKTOK_SHOP_CIPHER!);
+
+  const response = await sdk.return_refund.approveReturn({
+    return_id: '4035633475056536357',
+    query: {
+      idempotency_key: '40b456b1-78e7-412d-9fe6-82181496e1bd',
+    },
+    body: {
+      decision: 'APPROVE_RETURN',
+      buyer_keep_item: true,
+      // partial_refund: {
+      //   currency: "IDR",
+      //   amount: "100000"
+      // }
+    },
+  });
+
+  console.log(JSON.stringify(response));
+} catch (error) {
+  if (error instanceof TikTokAPIError) {
+    console.error('TikTok API Error:', error.message);
+    console.error('Status Code:', error.code);
+    console.log('Request Id: ', error.request_id);
+  } else {
+    console.error('Unexpected error:', error);
+  }
+}
+```
+
+---
+
+## Response Example
+
+```json
+{
+  "code": 0,
+  "data": {
+    "success": true,
+    "status": "APPROVED"
+  },
+  "message": "Success",
+  "request_id": "202407031300112233445566778899"
+}
+```
+
+---
+
+## Response Descriptions
+
+### Top-Level Fields
+
+| Field        | Type   | Description                    |
+| ------------ | ------ | ------------------------------ |
+| `code`       | int    | API status code (0 = success). |
+| `message`    | string | Operation message.             |
+| `request_id` | string | Unique request identifier.     |
+| `data`       | object | Contains approval result.      |
+
+---
+
+### `data` Object
+
+| Field     | Type    | Description                         |
+| --------- | ------- | ----------------------------------- |
+| `success` | boolean | Whether approval was successful.    |
+| `status`  | string  | Final status of the return request. |
+
+---
+
+## Error Handling
+
+All API errors will throw a `TikTokAPIError` containing:
+
+- **message**
+- **code**
+- **request_id**
+
+Full error reference:  
+https://partner.tiktokshop.com/docv2/page/approve-return-202309#Error_Code

--- a/apps/docs/core-api/return-and-refund/cancel-order.md
+++ b/apps/docs/core-api/return-and-refund/cancel-order.md
@@ -1,0 +1,132 @@
+# Cancel Order
+
+Cancel an order in TikTok Shop.
+
+Official documentation:  
+https://partner.tiktokshop.com/docv2/page/cancel-order-202309
+
+---
+
+## Requirements
+
+- A valid **Access Token**
+- A valid **Shop Cipher**
+- SDK Method: `return_refund.cancelOrder()`
+
+---
+
+## Parameters
+
+### Path / Main Parameters
+
+| Field      | Type   | Description                          |
+| ---------- | ------ | ------------------------------------ |
+| `order_id` | string | The order ID to cancel. **Required** |
+
+---
+
+### Query Parameters
+
+_No query parameters for this endpoint._
+
+---
+
+### Body Parameters
+
+| Field                 | Type     | Description                                            |
+| --------------------- | -------- | ------------------------------------------------------ |
+| `order_line_item_ids` | string[] | List of order line item IDs. **Required**              |
+| `skus`                | array    | Optional SKU cancellation list (`sku_id`, `quantity`). |
+| `cancel_reason`       | string   | Cancellation reason code. **Required**                 |
+
+---
+
+## Example Usage (TypeScript)
+
+```ts
+import { TikTokShopSDK, TikTokAPIError } from 'tiktok-shop-sdk';
+
+const sdk = new TikTokShopSDK({
+  appKey: process.env.TIKTOK_APP_KEY!,
+  appSecret: process.env.TIKTOK_APP_SECRET!,
+});
+
+try {
+  // Set Access Token
+  sdk.setAccessToken(process.env.TIKTOK_APP_ACCESS_KEY!);
+  sdk.setShopCipher(process.env.TIKTOK_SHOP_CIPHER!);
+
+  const response = await sdk.return_refund.cancelOrder({
+    order_id: '579489483240146725',
+    order_line_item_ids: ['580196086825061157'],
+    // skus: [
+    //     {
+    //         sku_id: "1731560413451420825",
+    //         quantity: 1
+    //     }
+    // ],
+    cancel_reason: 'ecom_order_to_ship_canceled_reason_change_payment_method',
+  });
+
+  console.log(JSON.stringify(response));
+} catch (error) {
+  if (error instanceof TikTokAPIError) {
+    console.error('TikTok API Error:', error.message);
+    console.error('Status Code:', error.code);
+    console.log('Request Id: ', error.request_id);
+  } else {
+    console.error('Unexpected error:', error);
+  }
+}
+```
+
+---
+
+## Response Example
+
+```json
+{
+  "code": 0,
+  "data": {
+    "success": true,
+    "cancel_status": "CANCELED"
+  },
+  "message": "Success",
+  "request_id": "202407031300998877665544332211"
+}
+```
+
+---
+
+## Response Descriptions
+
+### Top-Level Fields
+
+| Field        | Type   | Description                    |
+| ------------ | ------ | ------------------------------ |
+| `code`       | int    | API status code (0 = success). |
+| `message`    | string | Operation message.             |
+| `request_id` | string | Unique request identifier.     |
+| `data`       | object | Contains cancellation result.  |
+
+---
+
+### `data` Object
+
+| Field           | Type    | Description                     |
+| --------------- | ------- | ------------------------------- |
+| `success`       | boolean | Whether cancellation succeeded. |
+| `cancel_status` | string  | Final cancellation status.      |
+
+---
+
+## Error Handling
+
+All API errors will throw a `TikTokAPIError` containing:
+
+- **message**
+- **code**
+- **request_id**
+
+Full error reference:  
+https://partner.tiktokshop.com/docv2/page/cancel-order-202309#Error_Code

--- a/apps/docs/core-api/return-and-refund/create-return.md
+++ b/apps/docs/core-api/return-and-refund/create-return.md
@@ -1,0 +1,142 @@
+# Create Return
+
+Create a return request for an order in TikTok Shop.
+
+Official documentation:  
+https://partner.tiktokshop.com/docv2/page/create-return-202309
+
+---
+
+## Requirements
+
+- A valid **Access Token**
+- A valid **Shop Cipher**
+- SDK Method: `return_refund.createReturn()`
+
+---
+
+## Parameters
+
+### Query Parameters
+
+| Field             | Type   | Description                               |
+| ----------------- | ------ | ----------------------------------------- |
+| `idempotency_key` | string | Unique key to prevent duplicate requests. |
+
+---
+
+### Body Parameters
+
+| Field                 | Type     | Description                                  |
+| --------------------- | -------- | -------------------------------------------- |
+| `order_id`            | string   | The order ID. **Required**                   |
+| `skus`                | object[] | List of SKU items to return. **Required**    |
+| `order_line_item_ids` | string[] | Associated order line item IDs. **Required** |
+| `return_reason`       | string   | Reason for return. **Required**              |
+| `return_type`         | string   | Type of return, e.g., `RETURN_AND_REFUND`.   |
+| `refund_total`        | string   | Refund amount.                               |
+| `currency`            | string   | Currency code (e.g., IDR, USD).              |
+| `shipment_type`       | string   | Shipment type for the return.                |
+| `handover_method`     | string   | Handover method, e.g., `DROP_OFF`.           |
+
+---
+
+## Example Usage (TypeScript)
+
+```ts
+import { TikTokShopSDK, TikTokAPIError } from 'tiktok-shop-sdk';
+
+const sdk = new TikTokShopSDK({
+  appKey: process.env.TIKTOK_APP_KEY!,
+  appSecret: process.env.TIKTOK_APP_SECRET!,
+});
+
+try {
+  // Set Access Token
+  sdk.setAccessToken(process.env.TIKTOK_APP_ACCESS_KEY!);
+  sdk.setShopCipher(process.env.TIKTOK_SHOP_CIPHER!);
+
+  const response = await sdk.return_refund.createReturn({
+    body: {
+      order_id: '580195946180217637',
+      skus: [
+        {
+          sku_id: '1731560417292551321',
+          quantity: 1,
+        },
+      ],
+      order_line_item_ids: ['580196086825061157'],
+      return_reason: 'Damaged',
+      return_type: 'RETURN_AND_REFUND',
+      refund_total: '190000',
+      currency: 'IDR',
+      shipment_type: 'PLATFORM',
+      handover_method: 'DROP_OFF',
+    },
+    query: {
+      idempotency_key: 'ihdkgjfg876435',
+    },
+  });
+
+  console.log(response);
+} catch (error) {
+  if (error instanceof TikTokAPIError) {
+    console.error('TikTok API Error:', error.message);
+    console.error('Status Code:', error.code);
+    console.log('Request Id: ', error.request_id);
+  } else {
+    console.error('Unexpected error:', error);
+  }
+}
+```
+
+---
+
+## Response Example
+
+```json
+{
+  "code": 0,
+  "data": {
+    "return_id": "1234567890123456789",
+    "status": "PENDING"
+  },
+  "message": "Success",
+  "request_id": "202407031245009988776655AABBCC"
+}
+```
+
+---
+
+## Response Descriptions
+
+### Top-Level Fields
+
+| Field        | Type   | Description                       |
+| ------------ | ------ | --------------------------------- |
+| `code`       | int    | API status code (0 = success).    |
+| `message`    | string | Operation message.                |
+| `request_id` | string | Unique request identifier.        |
+| `data`       | object | Contains return creation details. |
+
+---
+
+### `data` Object
+
+| Field       | Type   | Description                      |
+| ----------- | ------ | -------------------------------- |
+| `return_id` | string | The generated return request ID. |
+| `status`    | string | Initial status of the request.   |
+
+---
+
+## Error Handling
+
+All API errors will throw a `TikTokAPIError` containing:
+
+- **message**
+- **code**
+- **request_id**
+
+Full error reference:  
+https://partner.tiktokshop.com/docv2/page/create-return-202309#Error_Code

--- a/apps/docs/core-api/return-and-refund/get-aftersale-eligibility.md
+++ b/apps/docs/core-api/return-and-refund/get-aftersale-eligibility.md
@@ -1,0 +1,125 @@
+# Get Aftersale Eligibility
+
+Check whether an order is eligible for aftersale (refund/return) operations.
+
+Official documentation:  
+https://partner.tiktokshop.com/docv2/page/get-aftersale-eligibility-202309
+
+---
+
+## Requirements
+
+- A valid **Access Token**
+- SDK Method: `return_refund.getAftersaleEligibility()`
+
+---
+
+## Parameters
+
+### Query Parameters
+
+| Field                           | Type   | Description                                       |
+| ------------------------------- | ------ | ------------------------------------------------- |
+| `order_id`                      | string | The ID of the order to check eligibility for.     |
+| `query.initiate_aftersale_user` | string | Who initiates the aftersale: `SELLER` or `BUYER`. |
+
+---
+
+## Example Usage (TypeScript)
+
+```ts
+import { TikTokShopSDK, TikTokAPIError } from 'tiktok-shop-sdk';
+
+const sdk = new TikTokShopSDK({
+  appKey: process.env.TIKTOK_APP_KEY!,
+  appSecret: process.env.TIKTOK_APP_SECRET!,
+});
+
+try {
+  // Set Access Token
+  sdk.setAccessToken(process.env.TIKTOK_APP_ACCESS_KEY!);
+  sdk.setShopCipher(process.env.TIKTOK_SHOP_CIPHER!);
+
+  const response = await sdk.return_refund.getAftersaleEligibility({
+    order_id: '580196086824799013',
+    query: {
+      initiate_aftersale_user: 'SELLER',
+    },
+  });
+
+  console.log(JSON.stringify(response));
+} catch (error) {
+  if (error instanceof TikTokAPIError) {
+    console.error('TikTok API Error:', error.message);
+    console.error('Status Code:', error.code);
+    console.log('Request Id: ', error.request_id);
+  } else {
+    console.error('Unexpected error:', error);
+  }
+}
+```
+
+---
+
+## Response Example
+
+```json
+{
+  "code": 0,
+  "message": "success",
+  "request_id": "202407011530000122334455",
+  "data": {
+    "eligible": true,
+    "reason": "",
+    "rules": [
+      {
+        "rule_code": "ALLOW_REFUND_ONLY",
+        "description": "Buyer is eligible for refund-only request."
+      }
+    ]
+  }
+}
+```
+
+---
+
+## Response Descriptions
+
+### Top-Level Fields
+
+| Field        | Type   | Description                         |
+| ------------ | ------ | ----------------------------------- |
+| `code`       | int    | Response status code (0 = success). |
+| `message`    | string | Description of the request result.  |
+| `request_id` | string | Unique ID for debugging/tracing.    |
+| `data`       | object | Eligibility result object.          |
+
+---
+
+### `data` Object
+
+| Field      | Type    | Description                                  |
+| ---------- | ------- | -------------------------------------------- |
+| `eligible` | boolean | Whether the order is eligible for aftersale. |
+| `reason`   | string  | Reason for ineligibility (if any).           |
+| `rules`    | array   | List of rules applied to eligibility.        |
+
+### `data.rules[]` Objects
+
+| Field         | Type   | Description                 |
+| ------------- | ------ | --------------------------- |
+| `rule_code`   | string | Internal rule identifier.   |
+| `description` | string | Human-readable explanation. |
+
+---
+
+## Error Handling
+
+All API errors throw a `TikTokAPIError` containing:
+
+- `message`
+- `code`
+- `request_id`
+
+Full error reference:  
+https://partner.tiktokshop.com/docv2/page/get-aftersale-eligibility-202309#Error_Code

--- a/apps/docs/core-api/return-and-refund/get-reject-reasons.md
+++ b/apps/docs/core-api/return-and-refund/get-reject-reasons.md
@@ -1,0 +1,114 @@
+# Get Reject Reasons
+
+Retrieve the list of valid reject reasons for a return or cancellation request in TikTok Shop.
+
+Official documentation:  
+https://partner.tiktokshop.com/docv2/page/get-reject-reasons-202309
+
+---
+
+## Requirements
+
+- A valid **Access Token**
+- A valid **Shop Cipher**
+- SDK Method: `return_refund.getRejectReasons()`
+
+---
+
+## Parameters
+
+| Parameter             | Type   | Description                                   |
+| --------------------- | ------ | --------------------------------------------- |
+| `return_or_cancel_id` | string | The return or cancel request ID. **Required** |
+
+---
+
+## Example Usage (TypeScript)
+
+```ts
+import { TikTokShopSDK, TikTokAPIError } from 'tiktok-shop-sdk';
+
+const sdk = new TikTokShopSDK({
+  appKey: process.env.TIKTOK_APP_KEY!,
+  appSecret: process.env.TIKTOK_APP_SECRET!,
+});
+
+try {
+  // Set Access Token
+  sdk.setAccessToken(process.env.TIKTOK_APP_ACCESS_KEY!);
+  sdk.setShopCipher(process.env.TIKTOK_SHOP_CIPHER!);
+
+  const response = await sdk.return_refund.getRejectReasons({
+    return_or_cancel_id: '4035633471902223141',
+  });
+
+  console.log(JSON.stringify(response));
+} catch (error) {
+  if (error instanceof TikTokAPIError) {
+    console.error('TikTok API Error:', error.message);
+    console.error('Status Code:', error.code);
+    console.log('Request Id: ', error.request_id);
+  } else {
+    console.error('Unexpected error:', error);
+  }
+}
+```
+
+---
+
+## Response Example
+
+```json
+{
+  "code": 0,
+  "data": {
+    "reject_reasons": [
+      {
+        "reason_code": "R001",
+        "reason_description": "Item not eligible for return"
+      },
+      {
+        "reason_code": "R002",
+        "reason_description": "Evidence provided is insufficient"
+      }
+    ]
+  },
+  "message": "Success",
+  "request_id": "202407021210000112233445566AABB"
+}
+```
+
+---
+
+## Response Descriptions
+
+### Top-Level Fields
+
+| Field        | Type   | Description                     |
+| ------------ | ------ | ------------------------------- |
+| `code`       | int    | API status code (0 = success).  |
+| `message`    | string | Operation message or reason.    |
+| `request_id` | string | Unique request identifier.      |
+| `data`       | object | Contains reject reason details. |
+
+---
+
+### `data.reject_reasons[]` Object
+
+| Field                | Type   | Description                          |
+| -------------------- | ------ | ------------------------------------ |
+| `reason_code`        | string | Code representing the reject reason. |
+| `reason_description` | string | Description of the reject reason.    |
+
+---
+
+## Error Handling
+
+All API errors throw a `TikTokAPIError` containing:
+
+- **message**
+- **code**
+- **request_id**
+
+Full error reference:  
+https://partner.tiktokshop.com/docv2/page/get-reject-reasons-202309#Error_Code

--- a/apps/docs/core-api/return-and-refund/get-return-records.md
+++ b/apps/docs/core-api/return-and-refund/get-return-records.md
@@ -1,0 +1,130 @@
+# Get Return Records
+
+Retrieve detailed return records for a specific return request in TikTok Shop.
+
+Official documentation:  
+https://partner.tiktokshop.com/docv2/page/get-return-records-202309
+
+---
+
+## Requirements
+
+- A valid **Access Token**
+- A valid **Shop Cipher**
+- SDK Method: `return_refund.getReturnRecord()`
+
+---
+
+## Parameters
+
+### Query Parameters
+
+This endpoint does **not** require query parameters.
+
+---
+
+### Body Parameters
+
+| Field       | Type   | Description                         |
+| ----------- | ------ | ----------------------------------- |
+| `return_id` | string | The return request ID. **Required** |
+
+---
+
+## Example Usage (TypeScript)
+
+```ts
+import { TikTokShopSDK, TikTokAPIError } from 'tiktok-shop-sdk';
+
+const sdk = new TikTokShopSDK({
+  appKey: process.env.TIKTOK_APP_KEY!,
+  appSecret: process.env.TIKTOK_APP_SECRET!,
+});
+
+try {
+  // Set Access Token
+  sdk.setAccessToken(process.env.TIKTOK_APP_ACCESS_KEY!);
+  sdk.setShopCipher(process.env.TIKTOK_SHOP_CIPHER!);
+
+  const response = await sdk.return_refund.getReturnRecord({
+    return_id: '4035633471902223141',
+  });
+
+  console.log(JSON.stringify(response));
+} catch (error) {
+  if (error instanceof TikTokAPIError) {
+    console.error('TikTok API Error:', error.message);
+    console.error('Status Code:', error.code);
+    console.log('Request Id:', error.request_id);
+  } else {
+    console.error('Unexpected error:', error);
+  }
+}
+```
+
+---
+
+## Response Example
+
+```json
+{
+  "code": 0,
+  "data": {
+    "return_id": "4035633471902223141",
+    "records": [
+      {
+        "status": "PENDING",
+        "timestamp": 1691234567,
+        "description": "Return request submitted by buyer"
+      }
+    ]
+  },
+  "message": "Success",
+  "request_id": "202407041200112233445566AABBCC"
+}
+```
+
+---
+
+## Response Descriptions
+
+### Top-Level Fields
+
+| Field        | Type   | Description                     |
+| ------------ | ------ | ------------------------------- |
+| `code`       | int    | API status code (0 = success).  |
+| `message`    | string | Operation message.              |
+| `request_id` | string | Unique request identifier.      |
+| `data`       | object | Contains return record details. |
+
+---
+
+### `data` Object
+
+| Field       | Type     | Description                  |
+| ----------- | -------- | ---------------------------- |
+| `return_id` | string   | The return request ID.       |
+| `records`   | object[] | List of record history logs. |
+
+---
+
+### `records[]` Object
+
+| Field         | Type   | Description                            |
+| ------------- | ------ | -------------------------------------- |
+| `status`      | string | Status at the recorded step.           |
+| `timestamp`   | int    | Record creation time (Unix timestamp). |
+| `description` | string | Description of the event.              |
+
+---
+
+## Error Handling
+
+All API errors will throw a `TikTokAPIError` containing:
+
+- **message**
+- **code**
+- **request_id**
+
+Full error reference:  
+https://partner.tiktokshop.com/docv2/page/get-return-records-202309#Error_Code

--- a/apps/docs/core-api/return-and-refund/reject-cancellation.md
+++ b/apps/docs/core-api/return-and-refund/reject-cancellation.md
@@ -1,0 +1,142 @@
+# Reject Cancellation
+
+Reject a buyer's cancellation request in TikTok Shop.
+
+Official documentation:  
+https://partner.tiktokshop.com/docv2/page/reject-cancellation-202309
+
+---
+
+## Requirements
+
+- A valid **Access Token**
+- A valid **Shop Cipher**
+- SDK Method: `return_refund.rejectCancellation()`
+
+---
+
+## Parameters
+
+### Path / Main Parameters
+
+| Field       | Type   | Description                               |
+| ----------- | ------ | ----------------------------------------- |
+| `cancel_id` | string | The cancellation request ID. **Required** |
+
+---
+
+### Query Parameters
+
+| Field             | Type   | Description                              |
+| ----------------- | ------ | ---------------------------------------- |
+| `idempotency_key` | string | Unique key to prevent duplicate actions. |
+
+---
+
+### Body Parameters
+
+| Field           | Type     | Description                                                       |
+| --------------- | -------- | ----------------------------------------------------------------- |
+| `reject_reason` | string   | Reason code for rejecting the cancellation. **Required**          |
+| `comment`       | string   | Optional comment explaining the rejection.                        |
+| `images`        | object[] | Image evidence list (`image_id`, `mime_type`, `height`, `width`). |
+
+---
+
+## Example Usage (TypeScript)
+
+```ts
+import { TikTokShopSDK, TikTokAPIError } from 'tiktok-shop-sdk';
+
+const sdk = new TikTokShopSDK({
+  appKey: process.env.TIKTOK_APP_KEY!,
+  appSecret: process.env.TIKTOK_APP_SECRET!,
+});
+
+try {
+  // Set Access Token
+  sdk.setAccessToken(process.env.TIKTOK_APP_ACCESS_KEY!);
+  sdk.setShopCipher(process.env.TIKTOK_SHOP_CIPHER!);
+
+  const response = await sdk.return_refund.rejectCancellation({
+    cancel_id: '09830495345435',
+    query: {
+      idempotency_key: '03498530l94056',
+    },
+    body: {
+      reject_reason: 'seller_reject_apply_product_has_been_packed',
+      comment: 'I have packed the products before cancellation request',
+      images: [
+        {
+          image_id:
+            'tos-maliva-i-o3syd03w52-us/57a1c8908fe74572861ea5e50887d8d1',
+          mime_type: 'image/png',
+          height: 200,
+          width: 200,
+        },
+      ],
+    },
+  });
+
+  console.log(JSON.stringify(response));
+} catch (error) {
+  if (error instanceof TikTokAPIError) {
+    console.error('TikTok API Error:', error.message);
+    console.error('Status Code:', error.code);
+    console.log('Request Id: ', error.request_id);
+  } else {
+    console.error('Unexpected error:', error);
+  }
+}
+```
+
+---
+
+## Response Example
+
+```json
+{
+  "code": 0,
+  "data": {
+    "success": true,
+    "status": "CANCELLATION_REJECTED"
+  },
+  "message": "Success",
+  "request_id": "202407031330998877665544AA"
+}
+```
+
+---
+
+## Response Descriptions
+
+### Top-Level Fields
+
+| Field        | Type   | Description                    |
+| ------------ | ------ | ------------------------------ |
+| `code`       | int    | API status code (0 = success). |
+| `message`    | string | Operation message.             |
+| `request_id` | string | Unique request identifier.     |
+| `data`       | object | Contains rejection result.     |
+
+---
+
+### `data` Object
+
+| Field     | Type    | Description                               |
+| --------- | ------- | ----------------------------------------- |
+| `success` | boolean | Whether the rejection was successful.     |
+| `status`  | string  | Final status of the cancellation request. |
+
+---
+
+## Error Handling
+
+All API errors will throw a `TikTokAPIError` containing:
+
+- **message**
+- **code**
+- **request_id**
+
+Full error reference:  
+https://partner.tiktokshop.com/docv2/page/reject-cancellation-202309#Error_Code

--- a/apps/docs/core-api/return-and-refund/reject-return.md
+++ b/apps/docs/core-api/return-and-refund/reject-return.md
@@ -1,0 +1,126 @@
+# Reject Return
+
+Reject a return request submitted by the buyer in TikTok Shop.
+
+Official documentation:  
+https://partner.tiktokshop.com/docv2/page/reject-return-202309
+
+---
+
+## Requirements
+
+- A valid **Access Token**
+- A valid **Shop Cipher**
+- SDK Method: `return_refund.rejectReturn()`
+
+---
+
+## Parameters
+
+### Query Parameters
+
+| Field             | Type   | Description                               |
+| ----------------- | ------ | ----------------------------------------- |
+| `idempotency_key` | string | Unique key to prevent duplicate requests. |
+
+---
+
+### Body Parameters
+
+| Field           | Type   | Description                                        |
+| --------------- | ------ | -------------------------------------------------- |
+| `decision`      | string | Must be `REJECT_RETURN`. **Required**              |
+| `reject_reason` | string | Reason code for rejecting the return. **Required** |
+| `comment`       | string | Additional explanation for the rejection.          |
+
+---
+
+## Example Usage (TypeScript)
+
+```ts
+import { TikTokShopSDK, TikTokAPIError } from 'tiktok-shop-sdk';
+
+const sdk = new TikTokShopSDK({
+  appKey: process.env.TIKTOK_APP_KEY!,
+  appSecret: process.env.TIKTOK_APP_SECRET!,
+});
+
+try {
+  // Set Access Token
+  sdk.setAccessToken(process.env.TIKTOK_APP_ACCESS_KEY!);
+  sdk.setShopCipher(process.env.TIKTOK_SHOP_CIPHER!);
+
+  const response = await sdk.return_refund.rejectReturn({
+    return_id: '4035633471902223141',
+    query: {
+      idempotency_key: '40b456b1-78e7-412d-9fe6-82181496e1bd',
+    },
+    body: {
+      decision: 'REJECT_RETURN',
+      reject_reason: 'reverse_reject_request_reason_2',
+      comment: 'I have reached an agreement with the buyer',
+    },
+  });
+
+  console.log(JSON.stringify(response));
+} catch (error) {
+  if (error instanceof TikTokAPIError) {
+    console.error('TikTok API Error:', error.message);
+    console.error('Status Code:', error.code);
+    console.log('Request Id: ', error.request_id);
+  } else {
+    console.error('Unexpected error:', error);
+  }
+}
+```
+
+---
+
+## Response Example
+
+```json
+{
+  "code": 0,
+  "data": {
+    "return_id": "4035633471902223141",
+    "status": "REJECTED"
+  },
+  "message": "Success",
+  "request_id": "202407031256009988776655AABBCC"
+}
+```
+
+---
+
+## Response Descriptions
+
+### Top-Level Fields
+
+| Field        | Type   | Description                       |
+| ------------ | ------ | --------------------------------- |
+| `code`       | int    | API status code (0 = success).    |
+| `message`    | string | Operation message.                |
+| `request_id` | string | Unique request identifier.        |
+| `data`       | object | Contains return decision details. |
+
+---
+
+### `data` Object
+
+| Field       | Type   | Description                       |
+| ----------- | ------ | --------------------------------- |
+| `return_id` | string | The return request ID.            |
+| `status`    | string | Final status after the rejection. |
+
+---
+
+## Error Handling
+
+All API errors will throw a `TikTokAPIError` containing:
+
+- **message**
+- **code**
+- **request_id**
+
+Full error reference:  
+https://partner.tiktokshop.com/docv2/page/reject-return-202309#Error_Code

--- a/apps/docs/core-api/return-and-refund/search-cancellations.md
+++ b/apps/docs/core-api/return-and-refund/search-cancellations.md
@@ -1,0 +1,156 @@
+# Search Cancellations
+
+Search cancellation records in TikTok Shop.
+
+Official documentation:  
+https://partner.tiktokshop.com/docv2/page/search-cancellations-202309
+
+---
+
+## Requirements
+
+- A valid **Access Token**
+- A valid **Shop Cipher**
+- SDK Method: `return_refund.searchCancellation()`
+
+---
+
+## Parameters
+
+### Main Parameters
+
+| Field       | Type   | Description                                    |
+| ----------- | ------ | ---------------------------------------------- |
+| `cancel_id` | string | Specific cancellation ID to search (optional). |
+
+---
+
+### Query Parameters
+
+| Field       | Type   | Description                 |
+| ----------- | ------ | --------------------------- |
+| `page_size` | string | Number of records per page. |
+
+---
+
+### Body Parameters
+
+| Field            | Type     | Description                                        |
+| ---------------- | -------- | -------------------------------------------------- |
+| `cancel_ids`     | string[] | List of cancellation IDs to filter.                |
+| `order_ids`      | string[] | List of order IDs.                                 |
+| `buyer_user_ids` | string[] | Filter by buyer user IDs.                          |
+| `cancel_types`   | string[] | Types of cancellation, e.g., `CANCEL`.             |
+| `cancel_status`  | string[] | Status list, e.g., `CANCELLATION_REQUEST_PENDING`. |
+| `create_time_ge` | number   | Filter: creation time >= value.                    |
+| `create_time_lt` | number   | Filter: creation time < value.                     |
+| `update_time_ge` | number   | Filter: update time >= value.                      |
+| `update_time_lt` | number   | Filter: update time < value.                       |
+| `locale`         | string   | Response language, e.g., `en-US`.                  |
+
+---
+
+## Example Usage (TypeScript)
+
+```ts
+import { TikTokShopSDK, TikTokAPIError } from 'tiktok-shop-sdk';
+
+const sdk = new TikTokShopSDK({
+  appKey: process.env.TIKTOK_APP_KEY!,
+  appSecret: process.env.TIKTOK_APP_SECRET!,
+});
+
+try {
+  // Set Access Token
+  sdk.setAccessToken(process.env.TIKTOK_APP_ACCESS_KEY!);
+  sdk.setShopCipher(process.env.TIKTOK_SHOP_CIPHER!);
+
+  const response = await sdk.return_refund.searchCancellation({
+    query: {
+      page_size: '20',
+    },
+    cancel_id: '9083405345',
+    body: {
+      cancel_ids: ['577087614418520388'],
+      order_ids: ['577087614418520388'],
+      buyer_user_ids: ['7494845267308415300'],
+      cancel_types: ['CANCEL'],
+      cancel_status: ['CANCELLATION_REQUEST_PENDING'],
+      create_time_ge: 1690340825,
+      create_time_lt: 1690340825,
+      update_time_ge: 1690340825,
+      update_time_lt: 1690340825,
+      locale: 'en-US',
+    },
+  });
+
+  console.log(JSON.stringify(response));
+} catch (error) {
+  if (error instanceof TikTokAPIError) {
+    console.error('TikTok API Error:', error.message);
+    console.error('Status Code:', error.code);
+    console.log('Request Id: ', error.request_id);
+  } else {
+    console.error('Unexpected error:', error);
+  }
+}
+```
+
+---
+
+## Response Example
+
+```json
+{
+  "code": 0,
+  "message": "Success",
+  "request_id": "202407031322001122334455",
+  "data": {
+    "cancellations": [
+      {
+        "cancel_id": "577087614418520388",
+        "order_id": "577087614418520388",
+        "status": "CANCELLATION_REQUEST_PENDING",
+        "buyer_user_id": "7494845267308415300"
+      }
+    ]
+  }
+}
+```
+
+---
+
+## Response Descriptions
+
+### Top-Level Fields
+
+| Field        | Type   | Description                    |
+| ------------ | ------ | ------------------------------ |
+| `code`       | int    | API status code (0 = success). |
+| `message`    | string | Operation message.             |
+| `request_id` | string | Unique request identifier.     |
+| `data`       | object | Cancellation search result.    |
+
+---
+
+### `data.cancellations[]` Object
+
+| Field           | Type   | Description                  |
+| --------------- | ------ | ---------------------------- |
+| `cancel_id`     | string | Cancellation request ID.     |
+| `order_id`      | string | Associated order ID.         |
+| `status`        | string | Current cancellation status. |
+| `buyer_user_id` | string | Buyer’s unique user ID.      |
+
+---
+
+## Error Handling
+
+All API errors will throw a `TikTokAPIError` containing:
+
+- **message**
+- **code**
+- **request_id**
+
+Full error reference:  
+https://partner.tiktokshop.com/docv2/page/search-cancellations-202309#Error_Code

--- a/apps/docs/core-api/return-and-refund/search-returns.md
+++ b/apps/docs/core-api/return-and-refund/search-returns.md
@@ -1,0 +1,128 @@
+# Search Returns
+
+Search and filter return requests in TikTok Shop.
+
+Official documentation:  
+https://partner.tiktokshop.com/docv2/page/search-returns-202309
+
+---
+
+## Requirements
+
+- A valid **Access Token**
+- A valid **Shop Cipher**
+- SDK Method: `return_refund.searchReturn()`
+
+---
+
+## Parameters
+
+### Query Parameters
+
+| Field        | Type   | Description                     |
+| ------------ | ------ | ------------------------------- |
+| `page_size`  | number | Number of results per page.     |
+| `page_token` | string | Token for pagination (optional) |
+
+---
+
+### Body Parameters
+
+| Field          | Type     | Description                                       |
+| -------------- | -------- | ------------------------------------------------- |
+| `return_types` | string[] | Filter by return types (e.g., RETURN_AND_REFUND). |
+
+---
+
+## Example Usage (TypeScript)
+
+```ts
+import { TikTokShopSDK, TikTokAPIError } from 'tiktok-shop-sdk';
+
+const sdk = new TikTokShopSDK({
+  appKey: process.env.TIKTOK_APP_KEY!,
+  appSecret: process.env.TIKTOK_APP_SECRET!,
+});
+
+try {
+  // Set Access Token
+  sdk.setAccessToken(process.env.TIKTOK_APP_ACCESS_KEY!);
+  sdk.setShopCipher(process.env.TIKTOK_SHOP_CIPHER!);
+
+  const response = await sdk.return_refund.searchReturn({
+    query: {
+      page_size: 10,
+    },
+    body: {
+      return_types: ['RETURN_AND_REFUND'],
+    },
+  });
+
+  console.log(JSON.stringify(response));
+} catch (error) {
+  if (error instanceof TikTokAPIError) {
+    console.error('TikTok API Error:', error.message);
+    console.error('Status Code:', error.code);
+    console.log('Request Id: ', error.request_id);
+  } else {
+    console.error('Unexpected error:', error);
+  }
+}
+```
+
+---
+
+## Response Example
+
+```json
+{
+  "code": 0,
+  "data": {
+    "returns": [
+      {
+        "return_id": "4035633471902223141",
+        "order_id": "580195946180217637",
+        "status": "PENDING"
+      }
+    ],
+    "page_token": "next-page-token"
+  },
+  "message": "Success",
+  "request_id": "202407041023009988776655AABBCC"
+}
+```
+
+---
+
+## Response Descriptions
+
+### Top-Level Fields
+
+| Field        | Type   | Description                    |
+| ------------ | ------ | ------------------------------ |
+| `code`       | int    | API status code (0 = success). |
+| `message`    | string | Operation message.             |
+| `request_id` | string | Unique request identifier.     |
+| `data`       | object | Contains return records.       |
+
+---
+
+### `data` Object
+
+| Field        | Type     | Description                          |
+| ------------ | -------- | ------------------------------------ |
+| `returns`    | object[] | List of return records.              |
+| `page_token` | string   | Token for the next page (if exists). |
+
+---
+
+## Error Handling
+
+All API errors will throw a `TikTokAPIError` containing:
+
+- **message**
+- **code**
+- **request_id**
+
+Full error reference:  
+https://partner.tiktokshop.com/docv2/page/search-returns-202309#Error_Code


### PR DESCRIPTION
This PR adds documentation for the return-and-refund module, covering cancellation flows, return creation, and aftersale eligibility checks. The following markdown files were introduced:

- `approve-cancellation.md`
- `approve-return.md`
- `cancel-order.md`
- `create-return.md`
- `get-aftersale-eligibility.md`
- `get-reject-reasons.md`
- `get-return-records.md`
- `reject-cancellation.md`
- `reject-return.md`
- `search-cancellations.md`
- `search-returns.md`

Each file includes request/response structure and usage notes to support adapter implementation and contributor onboarding. These docs aim to improve DX and ensure consistent handling of return and refund logic across TikTok's order lifecycle.
