### PR TITLE
fix: correct typo 'recomend' to 'recommend' in test description

### DIFF
--- a/packages/sdk/src/modules/__tests__/productModule.test.ts
+++ b/packages/sdk/src/modules/__tests__/productModule.test.ts
@@ -1558,7 +1558,7 @@ describe('ProductModule', () => {
       expect(result).toEqual(mockRes);
     });
 
-    it('Get product recomend title, desc using getRecommendedProductTitleAndDescription', async () => {
+    it('Get product recommend title, desc using getRecommendedProductTitleAndDescription', async () => {
       const mockRes: TikTokAPIResponse<GetRecommendedProductTitleAndDescriptionResponse> =
         {
           data: {


### PR DESCRIPTION
## Summary

- Fixed typo `recomend` → `recommend` in test description string

Closes #31

## Test plan

- [x] Existing tests pass (no functional change, only test name string)